### PR TITLE
Fix toast notification appearance on smaller screens

### DIFF
--- a/blocks/src/components/toast.rs
+++ b/blocks/src/components/toast.rs
@@ -74,7 +74,7 @@ pub fn ToastProvider(props: ToastProviderProps) -> Element {
 
         // Toast container - fixed position overlay
         div {
-            class: "fixed top-4 right-4 z-50 flex flex-col space-y-2 max-w-sm items-end pointer-events-none",
+            class: "fixed top-4 right-0 z-50 flex flex-col space-y-2 w-full max-w-sm px-4 items-end pointer-events-none",
             aria_live: "polite",
             aria_atomic: true,
 


### PR DESCRIPTION
This PR fixes issue https://github.com/Leaf-Computer/lumen-blocks/issues/26 where toast notifications would overflow on smaller mobile screens.

## Tests

**Lumen Blocks:** ed6f2d210450ddb105d63c102400c15811669e5b
**Platform:** Web (Safari)
**Steps:**
1. Trigger toast notifications while viewport has the size of a smaller mobile device (e.g. iPhone SE), ensure it is centred with proper padding around the edges.
2. Trigger toast notifications while the viewport is larger, and ensure it is aligned to the right, with proper sizing, and with proper padding around the edges.

<img width="573" height="763" alt="Screenshot 2025-07-12 at 10 52 33" src="https://github.com/user-attachments/assets/da002cff-daa6-4362-9300-673d773c8e82" />
<img width="1035" height="760" alt="Screenshot 2025-07-12 at 10 52 55" src="https://github.com/user-attachments/assets/836cebe3-2f63-49b4-a8e9-83f5508d4bbf" />

PASS
