### PR TITLE
Fix dropdown menu item mouse events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
 [[package]]
 name = "dioxus-primitives"
 version = "0.0.1"
-source = "git+https://github.com/DioxusLabs/components?rev=8d21a6b60b2cfd73dba569f33f5ca2bdd16d2f38#8d21a6b60b2cfd73dba569f33f5ca2bdd16d2f38"
+source = "git+https://github.com/DioxusLabs/components?rev=1398113b052211928e1146c93648eee17ac558b3#1398113b052211928e1146c93648eee17ac558b3"
 dependencies = [
  "dioxus",
  "dioxus-time",

--- a/blocks/Cargo.toml
+++ b/blocks/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Leaf-Computer/lumen-blocks"
 [dependencies]
 dioxus-lib.workspace = true
 dioxus-time.workspace = true
-dioxus-primitives = { git = "https://github.com/DioxusLabs/components", package = "dioxus-primitives", rev = "8d21a6b60b2cfd73dba569f33f5ca2bdd16d2f38" }
+dioxus-primitives = { git = "https://github.com/DioxusLabs/components", package = "dioxus-primitives", rev = "1398113b052211928e1146c93648eee17ac558b3" }
 tracing.workspace = true
 lucide-dioxus = { workspace = true, features = ["all-icons"] }
 log = "0.4"

--- a/blocks/src/components/dropdown.rs
+++ b/blocks/src/components/dropdown.rs
@@ -350,10 +350,10 @@ pub fn DropdownCheckboxItem(props: DropdownCheckboxItemProps) -> Element {
         DropdownMenuItem {
             class: item_classes,
             id: id_value,
-            value: ReadOnlySignal::new(Signal::new(value_str)),
-            index: ReadOnlySignal::new(Signal::new(index_val)),
+            value: ReadOnlySignal::<String>::new(Signal::new(value_str)),
+            index: ReadOnlySignal::<usize>::new(Signal::new(index_val)),
             disabled: disabled_val,
-            on_select: move |_| handle_change(),
+            on_select: move |_: String| handle_change(),
 
             // Checkbox indicator
             span {
@@ -457,7 +457,7 @@ pub fn DropdownRadioItem(props: DropdownRadioItemProps) -> Element {
     let context = use_context::<RadioGroupContext>();
 
     // Check if this item is selected based on context
-    let is_selected = *context.value.read() == props.value;
+    let is_selected: bool = *context.value.read() == props.value;
 
     // Determine item classes
     let item_classes = vec![
@@ -484,18 +484,17 @@ pub fn DropdownRadioItem(props: DropdownRadioItemProps) -> Element {
     // When selected, call the group's value change handler
     let value_for_handler = value_str.clone();
     let context_clone = context.clone();
-    let handle_select = move |_| {
-        context_clone.on_change.call(value_for_handler.clone());
-    };
 
     rsx! {
         DropdownMenuItem {
             class: item_classes,
             id: id_value,
-            value: ReadOnlySignal::new(Signal::new(value_str.clone())),
-            index: ReadOnlySignal::new(Signal::new(index_val)),
+            value: ReadOnlySignal::<String>::new(Signal::new(value_str.clone())),
+            index: ReadOnlySignal::<usize>::new(Signal::new(index_val)),
             disabled: disabled_val,
-            on_select: handle_select,
+            on_select: move |_: String| {
+                context_clone.on_change.call(value_for_handler.clone());
+            },
 
             // Radio indicator
             span {
@@ -544,7 +543,7 @@ pub fn DropdownItem(props: DropdownItemProps) -> Element {
     // Handle select event - clone value early to avoid move issues
     let value_for_handler = value_str.clone();
     let handler_clone = props.on_select.clone();
-    let handle_select = move |_| {
+    let handle_select = move |_: String| {
         if let Some(handler) = &handler_clone {
             handler.call(value_for_handler.clone());
         }
@@ -554,8 +553,8 @@ pub fn DropdownItem(props: DropdownItemProps) -> Element {
         DropdownMenuItem {
             class: item_classes,
             id: id_value,
-            value: value_str,
-            index: index_val,
+            value: ReadOnlySignal::<String>::new(Signal::new(value_str)),
+            index: ReadOnlySignal::<usize>::new(Signal::new(index_val)),
             disabled: disabled_val,
             on_select: handle_select,
 


### PR DESCRIPTION
This commit fixes an issue where dropdown menu items could not be clicked with a mouse, because the menu would close before the click event could complete.

The fix was first done upstream in Dioxus Primitives (4ca8fd51fe39e05b48708b92125866966ea18450), and then this commit updates the dependency version to include that fix.

Closes: https://github.com/Leaf-Computer/lumen-blocks/issues/39