### PR TITLE
input component extends input attributes

### DIFF
--- a/blocks/src/components/input.rs
+++ b/blocks/src/components/input.rs
@@ -111,6 +111,7 @@ pub struct InputProps {
     class: Option<String>,
 
     #[props(extends = GlobalAttributes)]
+    #[props(extends = input)]
     attributes: Vec<Attribute>,
 }
 


### PR DESCRIPTION
Allows input specific attributes like `min` and `max` to be passed.