### PR TITLE
Issue 65 build failure

### DIFF
--- a/docsite/docs/build.rs
+++ b/docsite/docs/build.rs
@@ -16,5 +16,9 @@ fn make_docs() {
 
     let filename = format!("router.rs");
 
+    // Don't try to trap this error - if the directory already exists, we don't care.
+    // If the directory can't be created, then the `write` call afterwards will fail, and we'll
+    // still see the error.
+    let _ = std::fs::create_dir(&out_dir);
     std::fs::write(out_dir.join(filename), out).unwrap();
 }

--- a/docsite/docs/src/docs.rs
+++ b/docsite/docs/src/docs.rs
@@ -4,6 +4,7 @@ use lucide_dioxus::{Check, Copy};
 use lumen_blocks::components::button::{Button, ButtonSize, ButtonVariant};
 use std::hash::Hash;
 
+// This module does not exist in the git repo - it is auto-generated at build time.
 pub mod router;
 
 #[component]


### PR DESCRIPTION
Close #65 by creating the relevant empty directory during the build phase.

I toyed with adding a `.gitkeep` file to keep the `docs` folder in the repo, but that can be a bit confusing when it's otherwise ignored so I thought the build script was a good place to make the directory.